### PR TITLE
[CFS-333] security fix: upgrade git dependency to address a security vulnerability

### DIFF
--- a/lib/mc_translator/version.rb
+++ b/lib/mc_translator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module McTranslator
-  VERSION = "0.1.6"
+  VERSION = '0.1.7'
 end

--- a/mc_translator.gemspec
+++ b/mc_translator.gemspec
@@ -1,38 +1,38 @@
 # frozen_string_literal: true
 
-require_relative "lib/mc_translator/version"
+require_relative 'lib/mc_translator/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "mc_translator"
+  spec.name          = 'mc_translator'
   spec.version       = McTranslator::VERSION
-  spec.authors       = ["justinjones53@gmail.com"]
-  spec.email         = ["justinjones53@gmail.com"]
+  spec.authors       = ['justinjones53@gmail.com']
+  spec.email         = ['justinjones53@gmail.com']
 
-  spec.summary       = "Translates locale files"
-  spec.description   = "Translates locale files"
-  spec.homepage      = "http://github.com/yankaindustries/mc_translator"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.summary       = 'Translates locale files'
+  spec.description   = 'Translates locale files'
+  spec.homepage      = 'http://github.com/yankaindustries/mc_translator'
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
-  # spec.metadata["allowed_push_host"] = "http://mygemserver.com"
+  # spec.metadata['allowed_push_host'] = 'http://mygemserver.com'
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "http://github.com/yankaindustries/mc_translator"
-  spec.metadata["changelog_uri"] = "http://github.com/yankaindustries/mc_translator"
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'http://github.com/yankaindustries/mc_translator'
+  spec.metadata['changelog_uri'] = 'http://github.com/yankaindustries/mc_translator'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "git", "~> 1.8.1"
-  spec.add_dependency "yaml", "~> 0.1.1"
-  spec.add_dependency "smartling", "~> 2.0.3"
-  spec.add_dependency "dotenv"
+  spec.add_dependency 'git', '~> 1.11.0'
+  spec.add_dependency 'yaml', '~> 0.1.1'
+  spec.add_dependency 'smartling', '~> 2.0.3'
+  spec.add_dependency 'dotenv'
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
[Jira ticket](https://masterclass-dev.atlassian.net/browse/CFS-333)

[Security vulnerability](https://github.com/advisories/GHSA-69p6-wvmq-27gg):
![Screen Shot 2022-04-29 at 15 44 23](https://user-images.githubusercontent.com/33032571/166006980-ebebd7d0-fccd-4d31-91cd-16a7c762f0db.png)

